### PR TITLE
Remove wrapper-repose namespacing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+Metrics/LineLength:
+  Max: 180
+
+Style/FileName:
+  Enabled: false
+
+Style/NumericLiterals:
+  MinDigits: 6

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ gem 'berkshelf'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-gem "test-kitchen"
-gem "kitchen-vagrant"
+gem 'test-kitchen'
+gem 'kitchen-vagrant'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   #   $ vagrant plugin install vagrant-omnibus
   #
-  if Vagrant.has_plugin?("vagrant-omnibus")
+  if Vagrant.has_plugin?('vagrant-omnibus')
     config.omnibus.chef_version = 'latest'
   end
 
@@ -26,7 +26,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # If this value is a shorthand to a box in Vagrant Cloud then
   # config.vm.box_url doesn't need to be specified.
   config.vm.box = 'chef/ubuntu-14.04'
-
 
   # Assign this VM to a host-only network IP, allowing you to access it
   # via the IP. Host-only networks can talk to the host machine as well as

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # tweaks to existing repose attributes
 
-default['wrapper-repose']['filters'] = %w(
+default['repose']['filters'] = %w(
   header-normalization,
   keystone-v2,
   extract-device-id,
@@ -50,50 +50,50 @@ default['repose']['header_normalization']['blacklist'] = [{
 
 # attributes for new recipes
 
-default['wrapper-repose']['extract_device_id']['cluster_id'] = ['all']
-default['wrapper-repose']['extract_device_id']['uri_regex'] = '.*/hybrid:\d+/entities/.*'
-default['wrapper-repose']['extract_device_id']['maas_service_uri'] = 'http://localhost:7010'
-default['wrapper-repose']['extract_device_id']['cache_timeout_millis'] = 60000
-default['wrapper-repose']['extract_device_id']['delegating_quality'] = nil
+default['repose']['extract_device_id']['cluster_id'] = ['all']
+default['repose']['extract_device_id']['uri_regex'] = '.*/hybrid:\d+/entities/.*'
+default['repose']['extract_device_id']['maas_service_uri'] = 'http://localhost:7010'
+default['repose']['extract_device_id']['cache_timeout_millis'] = 60000
+default['repose']['extract_device_id']['delegating_quality'] = nil
 
-default['wrapper-repose']['keystone_v2']['cluster_id'] = ['all']
-default['wrapper-repose']['keystone_v2']['uri_regex'] = nil
+default['repose']['keystone_v2']['cluster_id'] = ['all']
+default['repose']['keystone_v2']['uri_regex'] = nil
 
 # defaults are for dev/local (recipe overrides with encrypted data bag item by ele environment)
-default['wrapper-repose']['keystone_v2']['identity_username'] = 'identity_username'
-default['wrapper-repose']['keystone_v2']['identity_password'] = 'identity_p4ssw0rd'
+default['repose']['keystone_v2']['identity_username'] = 'identity_username'
+default['repose']['keystone_v2']['identity_password'] = 'identity_p4ssw0rd'
 
 # TODO: read this from somewhere else (already exists in chef?  surely...) and make dependent on environment
 # 'https://staging.identity.api.rackspacecloud.com'
 # 'https://identity.api.rackspacecloud.com'
-default['wrapper-repose']['keystone_v2']['identity_uri'] = 'http://identity.api.example.com'
-default['wrapper-repose']['keystone_v2']['identity_set_roles'] = true
-default['wrapper-repose']['keystone_v2']['identity_set_groups'] = false
-default['wrapper-repose']['keystone_v2']['identity_set_catalog'] = false
-default['wrapper-repose']['keystone_v2']['whitelist_uri_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/agent_installers/.+(\.sh)?'
-default['wrapper-repose']['keystone_v2']['tenant_uri_extraction_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/.+'
-default['wrapper-repose']['keystone_v2']['preauthorized_service_admin_role'] = nil
-default['wrapper-repose']['keystone_v2']['token_timeout_variability'] = 15
-default['wrapper-repose']['keystone_v2']['token_timeout'] = 600
+default['repose']['keystone_v2']['identity_uri'] = 'http://identity.api.example.com'
+default['repose']['keystone_v2']['identity_set_roles'] = true
+default['repose']['keystone_v2']['identity_set_groups'] = false
+default['repose']['keystone_v2']['identity_set_catalog'] = false
+default['repose']['keystone_v2']['whitelist_uri_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/agent_installers/.+(\.sh)?'
+default['repose']['keystone_v2']['tenant_uri_extraction_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/.+'
+default['repose']['keystone_v2']['preauthorized_service_admin_role'] = nil
+default['repose']['keystone_v2']['token_timeout_variability'] = 15
+default['repose']['keystone_v2']['token_timeout'] = 600
 
-default['wrapper-repose']['valkyrie_authorization']['cluster_id'] = ['all']
-default['wrapper-repose']['valkyrie_authorization']['uri_regex'] = '.*/hybrid:\d+/(?!agent_installers/).*'
-default['wrapper-repose']['valkyrie_authorization']['cache_timeout_millis'] = 60000
-default['wrapper-repose']['valkyrie_authorization']['enable_masking_403s'] = true
-default['wrapper-repose']['valkyrie_authorization']['delegating_quality'] = nil
+default['repose']['valkyrie_authorization']['cluster_id'] = ['all']
+default['repose']['valkyrie_authorization']['uri_regex'] = '.*/hybrid:\d+/(?!agent_installers/).*'
+default['repose']['valkyrie_authorization']['cache_timeout_millis'] = 60000
+default['repose']['valkyrie_authorization']['enable_masking_403s'] = true
+default['repose']['valkyrie_authorization']['delegating_quality'] = nil
 
 # TODO: make this dependent on environment
 # 'https://valkyrie.staging.my.rackspace.com'
 # 'https://valkyrie.my.rackspace.com'
-default['wrapper-repose']['valkyrie_authorization']['valkyrie_server_uri'] = 'http://valkyrie.my.example.com'
+default['repose']['valkyrie_authorization']['valkyrie_server_uri'] = 'http://valkyrie.my.example.com'
 
 # defaults are for dev/local (recipe overrides with encrypted data bag item by ele environment)
-default['wrapper-repose']['valkyrie_authorization']['valkyrie_server_username'] = 'username'
-default['wrapper-repose']['valkyrie_authorization']['valkyrie_server_password'] = 'p4ssw0rd'
+default['repose']['valkyrie_authorization']['valkyrie_server_username'] = 'username'
+default['repose']['valkyrie_authorization']['valkyrie_server_password'] = 'p4ssw0rd'
 
-default['wrapper-repose']['merge_header']['cluster_id'] = ['all']
-default['wrapper-repose']['merge_header']['uri_regex'] = nil
-default['wrapper-repose']['merge_header']['headers'] = %w(X-Roles X-Impersonator-Roles)
+default['repose']['merge_header']['cluster_id'] = ['all']
+default['repose']['merge_header']['uri_regex'] = nil
+default['repose']['merge_header']['headers'] = %w(X-Roles X-Impersonator-Roles)
 
 # TODO: check if this could conflict with another use of the java cookbook
 # java configuration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,25 +8,25 @@ default['wrapper-repose']['filters'] = %w(
   merge-header
 )
 
-#default['repose']['filters'] = %w(derp)
+# default['repose']['filters'] = %w(derp)
 
 default['repose']['endpoints'] = [{
-  :cluster_id => 'repose',
-  :id => node[:name],
-  :protocol => 'http',
-  :hostname => node[:fqdn],
-  :port => '8090',
-  :root_path => '/',
-  :default => true,
+  cluster_id: 'repose',
+  id: node[:name],
+  protocol: 'http',
+  hostname: node[:fqdn],
+  port: '8090',
+  root_path: '/',
+  default: true
 }]
 
 default['repose']['header_normalization']['uri_regex'] = nil
 default['repose']['header_normalization']['whitelist'] = []
 
 default['repose']['header_normalization']['blacklist'] = [{
-  :id => 'authorization',
-  :http_methods => 'ALL',
-  :headers => %w(
+  id: 'authorization',
+  http_methods: 'ALL',
+  headers: %w(
     X-Authorization
     X-Token-Expires
     X-Identity-Status
@@ -56,7 +56,6 @@ default['wrapper-repose']['extract_device_id']['maas_service_uri'] = 'http://loc
 default['wrapper-repose']['extract_device_id']['cache_timeout_millis'] = 60000
 default['wrapper-repose']['extract_device_id']['delegating_quality'] = nil
 
-
 default['wrapper-repose']['keystone_v2']['cluster_id'] = ['all']
 default['wrapper-repose']['keystone_v2']['uri_regex'] = nil
 
@@ -64,7 +63,7 @@ default['wrapper-repose']['keystone_v2']['uri_regex'] = nil
 default['wrapper-repose']['keystone_v2']['identity_username'] = 'identity_username'
 default['wrapper-repose']['keystone_v2']['identity_password'] = 'identity_p4ssw0rd'
 
-# TODO read this from somewhere else (already exists in chef?  surely...) and make dependent on environment
+# TODO: read this from somewhere else (already exists in chef?  surely...) and make dependent on environment
 # 'https://staging.identity.api.rackspacecloud.com'
 # 'https://identity.api.rackspacecloud.com'
 default['wrapper-repose']['keystone_v2']['identity_uri'] = 'http://identity.api.example.com'
@@ -77,14 +76,13 @@ default['wrapper-repose']['keystone_v2']['preauthorized_service_admin_role'] = n
 default['wrapper-repose']['keystone_v2']['token_timeout_variability'] = 15
 default['wrapper-repose']['keystone_v2']['token_timeout'] = 600
 
-
 default['wrapper-repose']['valkyrie_authorization']['cluster_id'] = ['all']
 default['wrapper-repose']['valkyrie_authorization']['uri_regex'] = '.*/hybrid:\d+/(?!agent_installers/).*'
 default['wrapper-repose']['valkyrie_authorization']['cache_timeout_millis'] = 60000
 default['wrapper-repose']['valkyrie_authorization']['enable_masking_403s'] = true
 default['wrapper-repose']['valkyrie_authorization']['delegating_quality'] = nil
 
-# TODO make this dependent on environment
+# TODO: make this dependent on environment
 # 'https://valkyrie.staging.my.rackspace.com'
 # 'https://valkyrie.my.rackspace.com'
 default['wrapper-repose']['valkyrie_authorization']['valkyrie_server_uri'] = 'http://valkyrie.my.example.com'
@@ -97,7 +95,7 @@ default['wrapper-repose']['merge_header']['cluster_id'] = ['all']
 default['wrapper-repose']['merge_header']['uri_regex'] = nil
 default['wrapper-repose']['merge_header']['headers'] = %w(X-Roles X-Impersonator-Roles)
 
-# TODO check if this could conflict with another use of the java cookbook
+# TODO: check if this could conflict with another use of the java cookbook
 # java configuration
 default['java']['install_flavor'] = 'oracle'
 default['java']['oracle']['accept_oracle_download_terms'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
-# TODO rename to maas-repose?
-name             'wrapper-repose'
-maintainer       'Rackspace'
+# TODO: rename to maas-repose?
+name 'wrapper-repose'
+maintainer 'Rackspace'
 maintainer_email 'YOUR_EMAIL'
-license          'Apache 2.0'
-description      'Installs/Configures wrapper-repose'
+license 'Apache 2.0'
+description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version          '0.1.1'
+version '0.1.1'
 
 # NOTE currently defined in Berksfile...defining here and loading via Berksfile not quite working :(

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,15 +9,15 @@ end
 
 include_recipe 'java'
 
-# TODO download https://ele-buildbot.cm.k1k.me/distfiles/custom-bundle/custom-bundle-1.0-SNAPSHOT.ear and place in /usr/share/repose/filters/
+# TODO: download https://ele-buildbot.cm.k1k.me/distfiles/custom-bundle/custom-bundle-1.0-SNAPSHOT.ear and place in /usr/share/repose/filters/
 
-# TODO update from wiki instructions https://one.rackspace.com/pages/viewpage.action?title=Install+Repose+on+ELE+VM&spaceKey=monitoring
+# TODO: update from wiki instructions https://one.rackspace.com/pages/viewpage.action?title=Install+Repose+on+ELE+VM&spaceKey=monitoring
 
 include_recipe 'repose'
 
 if %w(ele-stage ele-prod).include?(node.chef_environment)
   # load non-default secrets
-  repose_credentials = Chef::EncryptedDataBagItem.load("credentials", "repose")
+  repose_credentials = Chef::EncryptedDataBagItem.load('credentials', 'repose')
 
   identity_username = repose_credentials["identity_username_#{node.ele.env}"]
   identity_password = repose_credentials["identity_password_#{node.ele.env}"]
@@ -42,40 +42,40 @@ filters = node['wrapper-repose']['filters']
 services = node['repose']['services']
 
 filter_cluster_map = {
-  :'api-validator'          => node['repose']['api_validator'         ]['cluster_id'],
-  :'client-auth'            => node['repose']['client_auth'           ]['cluster_id'],
-  :'client-authorization'   => node['repose']['client_authorization'  ]['cluster_id'],
-  :'content-type-stripper'  => node['repose']['content_type_stripper' ]['cluster_id'],
-  :derp                     => node['repose']['derp'                  ]['cluster_id'],
-  :'header-identity'        => node['repose']['header_identity'       ]['cluster_id'],
-  :'header-normalization'   => node['repose']['header_normalization'  ]['cluster_id'],
-  :'header-translation'     => node['repose']['header_translation'    ]['cluster_id'],
-  :'ip-identity'            => node['repose']['ip_identity'           ]['cluster_id'],
-  :'rackspace-auth-user'    => node['repose']['rackspace_auth_user'   ]['cluster_id'],
-  :'rate-limiting'          => node['repose']['rate_limiting'         ]['cluster_id'],
-  :'slf4j-http-logging'     => node['repose']['slf4j_http_logging'    ]['cluster_id'],
-  :'translation'            => node['repose']['translation'           ]['cluster_id'],
-  :'uri-identity'           => node['repose']['uri_identity'          ]['cluster_id'],
-  :'keystone-v2'            => node['wrapper-repose']['keystone_v2'           ]['cluster_id'],
-  :'extract-device-id'      => node['wrapper-repose']['extract_device_id'     ]['cluster_id'],
+  :'api-validator'          => node['repose']['api_validator']['cluster_id'],
+  :'client-auth'            => node['repose']['client_auth']['cluster_id'],
+  :'client-authorization'   => node['repose']['client_authorization']['cluster_id'],
+  :'content-type-stripper'  => node['repose']['content_type_stripper']['cluster_id'],
+  :derp                     => node['repose']['derp']['cluster_id'],
+  :'header-identity'        => node['repose']['header_identity']['cluster_id'],
+  :'header-normalization'   => node['repose']['header_normalization']['cluster_id'],
+  :'header-translation'     => node['repose']['header_translation']['cluster_id'],
+  :'ip-identity'            => node['repose']['ip_identity']['cluster_id'],
+  :'rackspace-auth-user'    => node['repose']['rackspace_auth_user']['cluster_id'],
+  :'rate-limiting'          => node['repose']['rate_limiting']['cluster_id'],
+  :'slf4j-http-logging'     => node['repose']['slf4j_http_logging']['cluster_id'],
+  :translation            => node['repose']['translation']['cluster_id'],
+  :'uri-identity'           => node['repose']['uri_identity']['cluster_id'],
+  :'keystone-v2'            => node['wrapper-repose']['keystone_v2']['cluster_id'],
+  :'extract-device-id'      => node['wrapper-repose']['extract_device_id']['cluster_id'],
   :'valkyrie-authorization' => node['wrapper-repose']['valkyrie_authorization']['cluster_id'],
-  :'merge-header'           => node['wrapper-repose']['merge_header'          ]['cluster_id']
+  :'merge-header'           => node['wrapper-repose']['merge_header']['cluster_id']
 }
 
 filter_uri_regex_map = {
-  :'header-normalization'   => node['repose']['header_normalization'  ]['uri_regex'],
-  :'keystone-v2'            => node['wrapper-repose']['keystone_v2'           ]['uri_regex'],
-  :'extract-device-id'      => node['wrapper-repose']['extract_device_id'     ]['uri_regex'],
+  :'header-normalization'   => node['repose']['header_normalization']['uri_regex'],
+  :'keystone-v2'            => node['wrapper-repose']['keystone_v2']['uri_regex'],
+  :'extract-device-id'      => node['wrapper-repose']['extract_device_id']['uri_regex'],
   :'valkyrie-authorization' => node['wrapper-repose']['valkyrie_authorization']['uri_regex'],
-  :'merge-header'           => node['wrapper-repose']['merge_header'          ]['uri_regex']
+  :'merge-header'           => node['wrapper-repose']['merge_header']['uri_regex']
 }
 
 service_cluster_map = {
-    :'dist-datastore' => node['repose']['dist_datastore' ]['cluster_id']
+  :'dist-datastore' => node['repose']['dist_datastore']['cluster_id']
 }
 
 begin
-  r = resources(:template => "#{node['repose']['config_directory']}/system-model.cfg.xml")
+  r = resources(template: "#{node['repose']['config_directory']}/system-model.cfg.xml")
   r.cookbook 'repose-wrapper'
   r.source 'system-model.cfg.xml.erb'
   r.owner node['repose']['owner']
@@ -101,7 +101,7 @@ resources("template[#{node['repose']['config_directory']}/container.cfg.xml]").c
 
 resources("template[#{node['repose']['config_directory']}/system-model.cfg.xml]").cookbook 'wrapper-repose'
 
-# TODO make the version an attribute
+# TODO: make the version an attribute
 remote_file '/usr/share/repose/filters/custom-bundle-1.0-SNAPSHOT.ear' do
   source 'https://ele-buildbot.cm.k1k.me/distfiles/custom-bundle/custom-bundle-1.0-SNAPSHOT.ear'
   owner 'repose'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,7 @@ end
 
 # override various upstream cookbook definitions
 
-filters = node['wrapper-repose']['filters']
+filters = node['repose']['filters']
 
 services = node['repose']['services']
 
@@ -56,18 +56,18 @@ filter_cluster_map = {
   :'slf4j-http-logging'     => node['repose']['slf4j_http_logging']['cluster_id'],
   :translation            => node['repose']['translation']['cluster_id'],
   :'uri-identity'           => node['repose']['uri_identity']['cluster_id'],
-  :'keystone-v2'            => node['wrapper-repose']['keystone_v2']['cluster_id'],
-  :'extract-device-id'      => node['wrapper-repose']['extract_device_id']['cluster_id'],
-  :'valkyrie-authorization' => node['wrapper-repose']['valkyrie_authorization']['cluster_id'],
-  :'merge-header'           => node['wrapper-repose']['merge_header']['cluster_id']
+  :'keystone-v2'            => node['repose']['keystone_v2']['cluster_id'],
+  :'extract-device-id'      => node['repose']['extract_device_id']['cluster_id'],
+  :'valkyrie-authorization' => node['repose']['valkyrie_authorization']['cluster_id'],
+  :'merge-header'           => node['repose']['merge_header']['cluster_id']
 }
 
 filter_uri_regex_map = {
   :'header-normalization'   => node['repose']['header_normalization']['uri_regex'],
-  :'keystone-v2'            => node['wrapper-repose']['keystone_v2']['uri_regex'],
-  :'extract-device-id'      => node['wrapper-repose']['extract_device_id']['uri_regex'],
-  :'valkyrie-authorization' => node['wrapper-repose']['valkyrie_authorization']['uri_regex'],
-  :'merge-header'           => node['wrapper-repose']['merge_header']['uri_regex']
+  :'keystone-v2'            => node['repose']['keystone_v2']['uri_regex'],
+  :'extract-device-id'      => node['repose']['extract_device_id']['uri_regex'],
+  :'valkyrie-authorization' => node['repose']['valkyrie_authorization']['uri_regex'],
+  :'merge-header'           => node['repose']['merge_header']['uri_regex']
 }
 
 service_cluster_map = {
@@ -97,9 +97,9 @@ rescue Chef::Exceptions::ResourceNotFound
   Chef::Log.warn("template #{node['repose']['config_directory']}/system-model.cfg.xml not defined upstream")
 end
 
-resources("template[#{node['repose']['config_directory']}/container.cfg.xml]").cookbook 'wrapper-repose'
+resources("template[#{node['repose']['config_directory']}/container.cfg.xml]").cookbook 'repose'
 
-resources("template[#{node['repose']['config_directory']}/system-model.cfg.xml]").cookbook 'wrapper-repose'
+resources("template[#{node['repose']['config_directory']}/system-model.cfg.xml]").cookbook 'repose'
 
 # TODO: make the version an attribute
 remote_file '/usr/share/repose/filters/custom-bundle-1.0-SNAPSHOT.ear' do

--- a/recipes/filter-extract-device-id.rb
+++ b/recipes/filter-extract-device-id.rb
@@ -10,9 +10,9 @@ template "#{node['repose']['config_directory']}/extract-device-id.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :maas_service_uri => node['wrapper-repose']['extract_device_id']['maas_service_uri'],
-    :cache_timeout_millis => node['wrapper-repose']['extract_device_id']['cache_timeout_millis'],
-    :delegating_quality => node['wrapper-repose']['extract_device_id']['delegating_quality']
+    maas_service_uri: node['wrapper-repose']['extract_device_id']['maas_service_uri'],
+    cache_timeout_millis: node['wrapper-repose']['extract_device_id']['cache_timeout_millis'],
+    delegating_quality: node['wrapper-repose']['extract_device_id']['delegating_quality']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-extract-device-id.rb
+++ b/recipes/filter-extract-device-id.rb
@@ -10,9 +10,9 @@ template "#{node['repose']['config_directory']}/extract-device-id.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    maas_service_uri: node['wrapper-repose']['extract_device_id']['maas_service_uri'],
-    cache_timeout_millis: node['wrapper-repose']['extract_device_id']['cache_timeout_millis'],
-    delegating_quality: node['wrapper-repose']['extract_device_id']['delegating_quality']
+    maas_service_uri: node['repose']['extract_device_id']['maas_service_uri'],
+    cache_timeout_millis: node['repose']['extract_device_id']['cache_timeout_millis'],
+    delegating_quality: node['repose']['extract_device_id']['delegating_quality']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -10,17 +10,17 @@ template "#{node['repose']['config_directory']}/keystone-v2.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    identity_username: node['wrapper-repose']['keystone_v2']['identity_username'],
-    identity_password: node['wrapper-repose']['keystone_v2']['identity_password'],
-    identity_uri: node['wrapper-repose']['keystone_v2']['identity_uri'],
-    identity_set_roles: node['wrapper-repose']['keystone_v2']['identity_set_roles'],
-    identity_set_groups: node['wrapper-repose']['keystone_v2']['identity_set_groups'],
-    identity_set_catalog: node['wrapper-repose']['keystone_v2']['identity_set_catalog'],
-    whitelist_uri_regex: node['wrapper-repose']['keystone_v2']['whitelist_uri_regex'],
-    tenant_uri_extraction_regex: node['wrapper-repose']['keystone_v2']['tenant_uri_extraction_regex'],
-    preauthorized_service_admin_role: node['wrapper-repose']['keystone_v2']['preauthorized_service_admin_role'],
-    token_timeout_variability: node['wrapper-repose']['keystone_v2']['token_timeout_variability'],
-    token_timeout: node['wrapper-repose']['keystone_v2']['token_timeout']
+    identity_username: node['repose']['keystone_v2']['identity_username'],
+    identity_password: node['repose']['keystone_v2']['identity_password'],
+    identity_uri: node['repose']['keystone_v2']['identity_uri'],
+    identity_set_roles: node['repose']['keystone_v2']['identity_set_roles'],
+    identity_set_groups: node['repose']['keystone_v2']['identity_set_groups'],
+    identity_set_catalog: node['repose']['keystone_v2']['identity_set_catalog'],
+    whitelist_uri_regex: node['repose']['keystone_v2']['whitelist_uri_regex'],
+    tenant_uri_extraction_regex: node['repose']['keystone_v2']['tenant_uri_extraction_regex'],
+    preauthorized_service_admin_role: node['repose']['keystone_v2']['preauthorized_service_admin_role'],
+    token_timeout_variability: node['repose']['keystone_v2']['token_timeout_variability'],
+    token_timeout: node['repose']['keystone_v2']['token_timeout']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -10,17 +10,17 @@ template "#{node['repose']['config_directory']}/keystone-v2.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :identity_username => node['wrapper-repose']['keystone_v2']['identity_username'],
-    :identity_password => node['wrapper-repose']['keystone_v2']['identity_password'],
-    :identity_uri => node['wrapper-repose']['keystone_v2']['identity_uri'],
-    :identity_set_roles => node['wrapper-repose']['keystone_v2']['identity_set_roles'],
-    :identity_set_groups => node['wrapper-repose']['keystone_v2']['identity_set_groups'],
-    :identity_set_catalog => node['wrapper-repose']['keystone_v2']['identity_set_catalog'],
-    :whitelist_uri_regex => node['wrapper-repose']['keystone_v2']['whitelist_uri_regex'],
-    :tenant_uri_extraction_regex => node['wrapper-repose']['keystone_v2']['tenant_uri_extraction_regex'],
-    :preauthorized_service_admin_role => node['wrapper-repose']['keystone_v2']['preauthorized_service_admin_role'],
-    :token_timeout_variability => node['wrapper-repose']['keystone_v2']['token_timeout_variability'],
-    :token_timeout => node['wrapper-repose']['keystone_v2']['token_timeout']
+    identity_username: node['wrapper-repose']['keystone_v2']['identity_username'],
+    identity_password: node['wrapper-repose']['keystone_v2']['identity_password'],
+    identity_uri: node['wrapper-repose']['keystone_v2']['identity_uri'],
+    identity_set_roles: node['wrapper-repose']['keystone_v2']['identity_set_roles'],
+    identity_set_groups: node['wrapper-repose']['keystone_v2']['identity_set_groups'],
+    identity_set_catalog: node['wrapper-repose']['keystone_v2']['identity_set_catalog'],
+    whitelist_uri_regex: node['wrapper-repose']['keystone_v2']['whitelist_uri_regex'],
+    tenant_uri_extraction_regex: node['wrapper-repose']['keystone_v2']['tenant_uri_extraction_regex'],
+    preauthorized_service_admin_role: node['wrapper-repose']['keystone_v2']['preauthorized_service_admin_role'],
+    token_timeout_variability: node['wrapper-repose']['keystone_v2']['token_timeout_variability'],
+    token_timeout: node['wrapper-repose']['keystone_v2']['token_timeout']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-merge-header.rb
+++ b/recipes/filter-merge-header.rb
@@ -10,7 +10,7 @@ template "#{node['repose']['config_directory']}/merge-header.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    headers: node['wrapper-repose']['merge_header']['headers']
+    headers: node['repose']['merge_header']['headers']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-merge-header.rb
+++ b/recipes/filter-merge-header.rb
@@ -10,8 +10,7 @@ template "#{node['repose']['config_directory']}/merge-header.cfg.xml" do
   group node['repose']['group']
   mode '0644'
   variables(
-    :headers => node['wrapper-repose']['merge_header']['headers']
+    headers: node['wrapper-repose']['merge_header']['headers']
   )
   notifies :restart, 'service[repose-valve]'
 end
-

--- a/recipes/filter-valkyrie-authorization.rb
+++ b/recipes/filter-valkyrie-authorization.rb
@@ -10,13 +10,13 @@ template "#{node['repose']['config_directory']}/valkyrie-authorization.cfg.xml" 
   group node['repose']['group']
   mode '0644'
   variables(
-    cache_timeout_millis: node['wrapper-repose']['valkyrie_authorization']['cache_timeout_millis'],
-    enable_masking_403s: node['wrapper-repose']['valkyrie_authorization']['enable_masking_403s'],
-    delegating_quality: node['wrapper-repose']['valkyrie_authorization']['delegating_quality'],
-    valkyrie_server_uri: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_uri'],
-    valkyrie_server_username: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_username'],
-    valkyrie_server_password: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_password'],
-    preauthorized_service_admin_role: node['wrapper-repose']['valkyrie_authorization']['preauthorized_service_admin_role']
+    cache_timeout_millis: node['repose']['valkyrie_authorization']['cache_timeout_millis'],
+    enable_masking_403s: node['repose']['valkyrie_authorization']['enable_masking_403s'],
+    delegating_quality: node['repose']['valkyrie_authorization']['delegating_quality'],
+    valkyrie_server_uri: node['repose']['valkyrie_authorization']['valkyrie_server_uri'],
+    valkyrie_server_username: node['repose']['valkyrie_authorization']['valkyrie_server_username'],
+    valkyrie_server_password: node['repose']['valkyrie_authorization']['valkyrie_server_password'],
+    preauthorized_service_admin_role: node['repose']['valkyrie_authorization']['preauthorized_service_admin_role']
   )
   notifies :restart, 'service[repose-valve]'
 end

--- a/recipes/filter-valkyrie-authorization.rb
+++ b/recipes/filter-valkyrie-authorization.rb
@@ -10,13 +10,13 @@ template "#{node['repose']['config_directory']}/valkyrie-authorization.cfg.xml" 
   group node['repose']['group']
   mode '0644'
   variables(
-    :cache_timeout_millis => node['wrapper-repose']['valkyrie_authorization']['cache_timeout_millis'],
-    :enable_masking_403s => node['wrapper-repose']['valkyrie_authorization']['enable_masking_403s'],
-    :delegating_quality => node['wrapper-repose']['valkyrie_authorization']['delegating_quality'],
-    :valkyrie_server_uri => node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_uri'],
-    :valkyrie_server_username => node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_username'],
-    :valkyrie_server_password => node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_password'],
-    :preauthorized_service_admin_role => node['wrapper-repose']['valkyrie_authorization']['preauthorized_service_admin_role']
+    cache_timeout_millis: node['wrapper-repose']['valkyrie_authorization']['cache_timeout_millis'],
+    enable_masking_403s: node['wrapper-repose']['valkyrie_authorization']['enable_masking_403s'],
+    delegating_quality: node['wrapper-repose']['valkyrie_authorization']['delegating_quality'],
+    valkyrie_server_uri: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_uri'],
+    valkyrie_server_username: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_username'],
+    valkyrie_server_password: node['wrapper-repose']['valkyrie_authorization']['valkyrie_server_password'],
+    preauthorized_service_admin_role: node['wrapper-repose']['valkyrie_authorization']['preauthorized_service_admin_role']
   )
   notifies :restart, 'service[repose-valve]'
 end


### PR DESCRIPTION
let's extend the `node[:repose]` namespace instead of making a new `node[:wrapper-repose]` namespace.

Based on #6.