### PR TITLE
Lengthen backend connection timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.10
+- extend timeouts for Repose-origin connections to 60 seconds
+
 # 0.2.9
 - use only base url for identity
 - ensure endpoint id is 'public_api'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,12 @@ default['repose']['endpoints'] = [{
   default: true
 }]
 
+default['repose']['connection_timeout'] = 60000 # in millis
+default['repose']['read_timeout'] = 60000 # in millis
+
+default['repose']['connection_pool']['socket_timeout'] = 60000 # in millis
+default['repose']['connection_pool']['connection_timeout'] = 60000 # in millis
+
 default['repose']['header_normalization']['uri_regex'] = nil
 default['repose']['header_normalization']['whitelist'] = []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.9'
+version '0.2.10'
 
 depends 'apt'
 depends 'java'


### PR DESCRIPTION
@jguice: the intent is to lengthen the connection timeouts so that long-running API requests don't cause Repose to throw a 503 (smoke test failures).

These attributes land in the container.cfg file and the http-connection-pool.cfg files.  (With these values, the problem is fixed.)

My question: is setting the values as I've done in the wrapper effective in overriding the attributes used in the base cookbook recipe [here](https://github.com/rackerlabs/cookbook-repose/blob/master/recipes/service-connection-pool.rb) targeting the template [here](https://github.com/rackerlabs/cookbook-repose/blob/master/templates/default/http-connection-pool.cfg.xml.erb).  (The container.cfg attribute usage is completely analogous AFAICT.)

My testbed is out-of-date, figured I'd ask before wasting a lot of time resuscitating it.