### PR TITLE
Pre-authorize hybridRole in Valkyrie filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.11
+- grant pre-authorized to hybridRole in Valkyrie filter
+
 # 0.2.10
 - extend timeouts for Repose-origin connections to 60 seconds
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.10'
+version '0.2.11'
 
 depends 'apt'
 depends 'java'

--- a/templates/default/valkyrie-authorization.cfg.xml.erb
+++ b/templates/default/valkyrie-authorization.cfg.xml.erb
@@ -57,4 +57,7 @@
             </collection>
         </resource>
     </collection-resources>
+    <pre-authorized-roles>
+        <role>hybridRole</role>
+    </pre-authorized-roles>
 </valkyrie-authorization>


### PR DESCRIPTION
Permits quasi-dedicated users with names of the form hybridNNNNNN carrying the hybridRole to continue to access public API.