### PR TITLE
Add X-Repose-Forwarded-Host header on all requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.12
+- insert X-Repose-Forwarded-Host header into all requests
+
 # 0.2.11
 - grant pre-authorized to hybridRole in Valkyrie filter
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@ default['repose']['peers'] = [{
 
 default['repose']['filters'] = %w(
   header-normalization
+  header-translation
   keystone-v2
   extract-device-id
   valkyrie-authorization
@@ -31,6 +32,7 @@ default['repose']['read_timeout'] = 60000 # in millis
 default['repose']['connection_pool']['socket_timeout'] = 60000 # in millis
 default['repose']['connection_pool']['connection_timeout'] = 60000 # in millis
 
+default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['uri_regex'] = nil
 default['repose']['header_normalization']['whitelist'] = []
 
@@ -66,6 +68,9 @@ default['repose']['group'] = 'repose'
 
 # attributes for new recipes
 default['repose']['bundle_name'] = 'custom-bundle-1.0-SNAPSHOT.ear'
+
+default['repose']['header_translation']['cluster_id'] = ['all']
+default['repose']['header_translation']['uri_regex'] = nil
 
 default['repose']['extract_device_id']['cluster_id'] = ['all']
 default['repose']['extract_device_id']['uri_regex'] = '.*/hybrid:\d+/entities/.*'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.11'
+version '0.2.12'
 
 depends 'apt'
 depends 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,6 +108,7 @@ end
 # NOTE these hash keys should be left as strings or system-model.cfg.xml.erb will break
 filter_cluster_map = {
   'header-normalization'   => node['repose']['header_normalization']['cluster_id'],
+  'header-translation'     => node['repose']['header_translation']['cluster_id'],
   'keystone-v2'            => node['repose']['keystone_v2']['cluster_id'],
   'extract-device-id'      => node['repose']['extract_device_id']['cluster_id'],
   'valkyrie-authorization' => node['repose']['valkyrie_authorization']['cluster_id'],
@@ -116,6 +117,7 @@ filter_cluster_map = {
 
 filter_uri_regex_map = {
   'header-normalization'   => node['repose']['header_normalization']['uri_regex'],
+  'header-translation'     => node['repose']['header_translation']['uri_regex'],
   'keystone-v2'            => node['repose']['keystone_v2']['uri_regex'],
   'extract-device-id'      => node['repose']['extract_device_id']['uri_regex'],
   'valkyrie-authorization' => node['repose']['valkyrie_authorization']['uri_regex'],

--- a/templates/default/header-translation.cfg.xml.erb
+++ b/templates/default/header-translation.cfg.xml.erb
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://docs.openrepose.org/repose/header-translation/v1.0 ../config/header-translation.xsd"
+                    xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+
+    <header original-name="Host" new-name="X-Repose-Forwarded-Host" remove-original="false"/>
+
+</header-translation>


### PR DESCRIPTION
Added a header-translation filter to the stack to preserve the original hostname.  Can't be fully tested until in staging.

Also, added cluster_id to existing header-normalization filter -- odd that it ever worked without it.