### PR TITLE
Use base cookbook recipe for adding header-translation filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.13
+- use base Repose cookbook to add header-translation filter
+
 # 0.2.12
 - insert X-Repose-Forwarded-Host header into all requests
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,11 @@ default['repose']['bundle_name'] = 'custom-bundle-1.0-SNAPSHOT.ear'
 
 default['repose']['header_translation']['cluster_id'] = ['all']
 default['repose']['header_translation']['uri_regex'] = nil
+default['repose']['header_translation']['headers'] = [{
+  original_name: 'Host',
+  new_name: 'X-Repose-Forwarded-Host',
+  remove_original: 'false'
+}]
 
 default['repose']['extract_device_id']['cluster_id'] = ['all']
 default['repose']['extract_device_id']['uri_regex'] = '.*/hybrid:\d+/entities/.*'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.12'
+version '0.2.13'
 
 depends 'apt'
 depends 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,7 @@ end
 include_recipe 'java'
 
 include_recipe 'repose::filter-header-normalization'
+include_recipe 'repose::filter-header-translation'
 include_recipe 'wrapper-repose::filter-extract-device-id'
 include_recipe 'wrapper-repose::filter-keystone-v2'
 include_recipe 'wrapper-repose::filter-merge-header'

--- a/templates/default/header-translation.cfg.xml.erb
+++ b/templates/default/header-translation.cfg.xml.erb
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://docs.openrepose.org/repose/header-translation/v1.0 ../config/header-translation.xsd"
-                    xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
-
-    <header original-name="Host" new-name="X-Repose-Forwarded-Host" remove-original="false"/>
-
-</header-translation>


### PR DESCRIPTION
@jguice: while testing the new header-translation filter (which preserves the Host header) in staging, I noticed that the deploy was incomplete because of a step I left out in 0.2.12.  

While fixing that, I realized that I should have used the recipe+template already in the base cookbook to add the header-translation filter (following the pattern of the header-normalization filter).  That's what this PR does.