### PR TITLE
Memorialize /pki hotfix and other small changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.15
+- whitelist /version to allow Nagios check to succeed
+- whitelist /pki/* to allow ServerMill to access keys without token
+- extend timeouts for origin connections to 600 seconds
+
 # 0.2.14
 - prevent extract-device-id filter from grabbing /entities/ request
 - remove masking of Valkyrie device level 403s

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,11 +26,11 @@ default['repose']['endpoints'] = [{
   default: true
 }]
 
-default['repose']['connection_timeout'] = 60000 # in millis
-default['repose']['read_timeout'] = 60000 # in millis
+default['repose']['connection_timeout'] = 600_000 # in millis
+default['repose']['read_timeout'] = 600_000 # in millis
 
-default['repose']['connection_pool']['socket_timeout'] = 60000 # in millis
-default['repose']['connection_pool']['connection_timeout'] = 60000 # in millis
+default['repose']['connection_pool']['socket_timeout'] = 600_000 # in millis
+default['repose']['connection_pool']['connection_timeout'] = 600_000 # in millis
 
 default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['uri_regex'] = nil
@@ -94,7 +94,11 @@ default['repose']['keystone_v2']['identity_uri'] = 'http://localhost:8900/identi
 default['repose']['keystone_v2']['identity_set_roles'] = true
 default['repose']['keystone_v2']['identity_set_groups'] = false
 default['repose']['keystone_v2']['identity_set_catalog'] = false
-default['repose']['keystone_v2']['whitelist_uri_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/agent_installers/.+(\.sh)?'
+default['repose']['keystone_v2']['whitelist_uri_regexes'] = %w(
+  .*/v1.0/(\d+|[a-zA-Z]+:\d+)/agent_installers/.+(\.sh)?
+  .*/pki/.*?
+  .*/version?
+)
 default['repose']['keystone_v2']['tenant_uri_extraction_regex'] = '.*/v1.0/(\d+|[a-zA-Z]+:\d+)/.+'
 default['repose']['keystone_v2']['preauthorized_service_admin_role'] = nil
 default['repose']['keystone_v2']['token_timeout_variability'] = 15

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.14'
+version '0.2.15'
 
 depends 'apt'
 depends 'java'

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -16,7 +16,7 @@ template "#{node['repose']['config_directory']}/keystone-v2.cfg.xml" do
     identity_set_roles: node['repose']['keystone_v2']['identity_set_roles'],
     identity_set_groups: node['repose']['keystone_v2']['identity_set_groups'],
     identity_set_catalog: node['repose']['keystone_v2']['identity_set_catalog'],
-    whitelist_uri_regex: node['repose']['keystone_v2']['whitelist_uri_regex'],
+    whitelist_uri_regexes: node['repose']['keystone_v2']['whitelist_uri_regexes'],
     tenant_uri_extraction_regex: node['repose']['keystone_v2']['tenant_uri_extraction_regex'],
     preauthorized_service_admin_role: node['repose']['keystone_v2']['preauthorized_service_admin_role'],
     token_timeout_variability: node['repose']['keystone_v2']['token_timeout_variability'],

--- a/templates/default/keystone-v2.cfg.xml.erb
+++ b/templates/default/keystone-v2.cfg.xml.erb
@@ -3,7 +3,9 @@
 <keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
     <identity-service username="<%= @identity_username %>" password="<%= @identity_password %>" uri="<%= @identity_uri %>" set-roles-in-header="<%= @identity_set_roles %>" set-groups-in-header="<%= @identity_set_catalog %>" set-catalog-in-header="<%= @identity_set_catalog %>" />
     <white-list>
-        <uri-regex><%= @whitelist_uri_regex %></uri-regex>
+        <% @whitelist_uri_regexes.each do |whitelist_uri_regex| %>
+        <uri-regex><%= whitelist_uri_regex %></uri-regex>
+        <% end %>
     </white-list>
     <tenant-handling>
         <validate-tenant>


### PR DESCRIPTION
This PR:

1. Memorializes the hotfix applied immediately after releasing Repose that whitelisted /pki/.* endpoints;
2. Fixes [this](https://github.com/racker/chef/blob/master/data_bags/nagios_services/https_api_rax.json) Nagios check (currently showing WARNING, and paging NebOps) by whitelisting the /version endpoint; and
3. Increases the timeout for the connection between Repose and the public API server to 600 seconds to fix other failing checks and anticipate longer running queries.