### PR TITLE
Upgrade to Repose 7.1.7.1 to fix server-crashing Valkyrie culling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0
+- upgrade Repose to version 7.1.7.1 (fix for Valkyrie culling bug)
+- set JVM min-heap == max-heap to avoid GC pause
+- reduce log4j2 logging
+
 # 0.2.19
 - complete fixes to runit support
 - expand log4j2 logging

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,7 +61,7 @@ default['repose']['header_normalization']['blacklist'] = [{
   )
 }]
 
-default['repose']['version'] = '7.1.7.0'
+default['repose']['version'] = '7.1.7.1'
 
 default['repose']['owner'] = 'repose'
 default['repose']['group'] = 'repose'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.2.19'
+version '0.3.0'
 
 depends 'apt'
 depends 'java'

--- a/templates/default/log4j2.xml.erb
+++ b/templates/default/log4j2.xml.erb
@@ -26,10 +26,6 @@
         <Logger name="com.sun.jersey" level="off"/>
         <Logger name="net.sf.ehcache" level="error"/>
         <Logger name="org.apache" level="info"/>
-        <Logger name="org.apache.http.headers" level="debug"/>
-        <Logger name="org.apache.http.impl.conn.DefaultClientConnection" level="debug"/>
-        <Logger name="org.openrepose.filters.custom.extractdeviceid" level="debug"/>
-        <Logger name="org.openrepose.filters.valkyrieauthorization" level="debug"/>
         <Logger name="org.eclipse.jetty" level="info"/>
         <Logger name="org.springframework" level="info"/>
         <Logger name="intrafilter-logging" level="info"/>

--- a/templates/default/sv-repose-valve-run.erb
+++ b/templates/default/sv-repose-valve-run.erb
@@ -7,7 +7,7 @@ USER=repose
 NAME=repose-valve
 DAEMON_HOME=/usr/share/repose
 REPOSE_JAR=${DAEMON_HOME}/${NAME}.jar
-JAVA_OPTS="-server -Xms2g -Xmx4g -XX:+UseG1GC"
+JAVA_OPTS="-server -Xms4g -Xmx4g -XX:+UseG1GC"
 RUN_OPTS="-c $CONFIG_DIRECTORY"
 
 exec chpst -u repose -- ${JAVA_BIN} ${JAVA_OPTS} -jar ${REPOSE_JAR} ${RUN_OPTS} 2>&1


### PR DESCRIPTION
NB: I thought (and may have told some folks) that we'd need to upgrade to 7.2.x.x, but I was wrong.

UPDATE: I should note, that I could not get 7.1.7.0 to fail in a non-production setting, so I can't definitively prove that this fixes it.