### PR TITLE
Enable rolling off of log backups.

### DIFF
--- a/templates/default/log4j2.xml.erb
+++ b/templates/default/log4j2.xml.erb
@@ -4,13 +4,12 @@
         <Console name="STDOUT">
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
         </Console>
-        <RollingFile name="RollingFile" fileName="/var/log/repose/current.log"
-                     filePattern="/var/log/repose/current-%d{yyyy-MM-dd_HHmmss}.log">
+        <RollingFile name="RollingFile" fileName="/var/log/repose/current.log" filePattern="/var/log/repose/current.%i.log">
             <PatternLayout pattern="Trans-Id:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="2"/>
+            <DefaultRolloverStrategy max="5"/>
         </RollingFile>
         <File name="PhoneHomeMessages" fileName="/var/log/repose/phone-home.log" append="false">
             <PatternLayout>


### PR DESCRIPTION
Limits the number of back-up logs to 5 (at ~200mb) each. 

Probably not worth a new release by itself, but can be swept into the upcoming Java release if desired.