### PR TITLE
Replace attribute-based java approach with explicit call

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,8 @@
 ---
 driver:
   name: vagrant
+  customize:
+    memory: 2560
 
 provisioner:
   name: chef_solo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.1
+- use java_ark LWRP directly to avoid conflicts with other attribute-based java cookbook usages
+- fix (useless) test
+- bump kitchen VM memory to 2.5G and initial repose heap to 2G
+
 # 0.3.0
 - upgrade Repose to version 7.1.7.1 (fix for Valkyrie culling bug)
 - set JVM min-heap == max-heap to avoid GC pause

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,12 +118,3 @@ default['repose']['valkyrie_authorization']['valkyrie_server_password'] = 'valky
 default['repose']['merge_header']['cluster_id'] = ['all']
 default['repose']['merge_header']['uri_regex'] = nil
 default['repose']['merge_header']['headers'] = %w(X-Roles X-Impersonator-Roles)
-
-default['java']['install_flavor'] = 'oracle'
-default['java']['oracle']['accept_oracle_download_terms'] = true
-default['java']['jdk_version'] = '8' # override_default
-default['java']['arch'] = 'x86_64' # ensure this is set (nil kernel[:machine] in some cases)
-default['java']['jdk']['8']['x86_64']['url'] = 'http://f203e7ccada4106422d5-525efbc04163a45a7d6a38d479995b34.r68.cf2.rackcdn.com/jdk-8u60-linux-x64.tar.gz'
-default['java']['set_default'] = false
-default['java']['reset_alternatives'] = false
-default['java']['use_alt_suffix'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures wrapper-repose'
 long_description 'Installs/Configures wrapper-repose'
-version '0.3.0'
+version '0.3.1'
 
 depends 'apt'
 depends 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,15 @@
 require 'uri'
 
-include_recipe 'java'
+# extract-device-id filter requires java 1.8
+java_ark 'jdk' do
+  url 'http://f203e7ccada4106422d5-525efbc04163a45a7d6a38d479995b34.r68.cf2.rackcdn.com/jdk-8u60-linux-x64.tar.gz'
+  checksum '1ab9805c5c1b20d56ac287613c3ffa9fc74f2a0dc0fcf1a9eea90811964a5055'
+  app_home '/usr/lib/jvm'
+  default false
+  reset_alternatives false
+  use_alt_suffix false
+  action :install
+end
 
 include_recipe 'wrapper-repose::log4j2'
 
@@ -13,13 +22,12 @@ include_recipe 'wrapper-repose::filter-valkyrie-authorization'
 
 include_recipe 'repose::install'
 
+include_recipe 'runit'
+
 # NOTE repose::default is mostly copied here due to the following code (which makes wrapping nigh impossible):
 # https://github.com/rackerlabs/cookbook-repose/blob/31a561526a1d393b1d7ef8370be26b3999e01f84/recipes/default.rb#L93
 
-runit_service 'repose-valve' do
-  log_owner 'daemon'
-  log_group 'daemon'
-end
+runit_service 'repose-valve'
 
 include_recipe 'repose::load_peers' if node['repose']['peer_search_enabled']
 

--- a/templates/default/sv-repose-valve-run.erb
+++ b/templates/default/sv-repose-valve-run.erb
@@ -7,7 +7,7 @@ USER=repose
 NAME=repose-valve
 DAEMON_HOME=/usr/share/repose
 REPOSE_JAR=${DAEMON_HOME}/${NAME}.jar
-JAVA_OPTS="-server -Xms4g -Xmx4g -XX:+UseG1GC"
+JAVA_OPTS="-server -Xms2g -Xmx4g -XX:+UseG1GC"
 RUN_OPTS="-c $CONFIG_DIRECTORY"
 
 exec chpst -u repose -- ${JAVA_BIN} ${JAVA_OPTS} -jar ${REPOSE_JAR} ${RUN_OPTS} 2>&1

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -8,7 +8,7 @@ describe file('/etc/sysconfig/repose') do
   it { should be_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
-  it { should be_mode 755 }
+  it { should be_mode 644 }
 end
 
 describe file('/etc/repose/system-model.cfg.xml') do


### PR DESCRIPTION
Allows java cookbook to be configured elsewhere using attributes (previously caused a conflict).  e.g. racker/chef#3051

Also fixes a (now useless) test and sets the default initial heap to 2G (and bumps the kitchen vm to 2.5 so repose can start).